### PR TITLE
Working group membership

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,10 @@ Define and execute a long-term support (LTS) plan for the io.js process.
 
 ## Working Group Members
 
-_To be filled in_
+* Rod Vagg [GitHub/@rvagg](https://github.com/rvagg) / [Twitter/@rvagg](https://twitter.com/rvagg)
+* Ben Noordhuis [GitHub/@bnoordhuis](https://github.com/bnoordhuis) / [Twitter/@bnoordhuis](http://twitter.com/bnoordhuis)
+* Trevor Norris [GitHub/@trevnorris](https://github.com/trevnorris) / [Twitter/@trevnorris](https://twitter.com/trevnorris)
+* Thorsten Lorenz [GitHub/@thlorenz](https://github.com/thlorenz) / [Twitter/@thlorenz](https://twitter.com/thlorenz)
+* Fedor Indutny [GitHub/@indutny](https://github.com/indutny) / [Twitter/@indutny](https://twitter.com/indutny)
+* Wyatt Preul [GitHub/@geek](https://github.com/geek) / [Twitter/@wpreul](https://twitter.com/wpreul)
+


### PR DESCRIPTION
Ideally this working group should be run by _doers_ rather than _talkers_, so people either with the time to devote to maintaining LTS branches and releases or are able to represent resources to devote to this.

I haven't actually consulted properly with the initial list of people I'm proposing in this PR, so this is not authoritative, simply a way to kickstart the discussion.

I'm pulling in NodeSource folk because we have very strongly aligned interests here: @rvagg, @trevnorris, @thlorenz.

I've pulled in StrongLoop via @bnoordhuis, perhaps there's others that could be nominated? I know StrongLoop is similarly aligned with LTS needs.

I've pulled in @indutny for Voxer, I don't know how good the alignment or fit here is, feel free to comment Fedor.

I've pulled in @geek for Walmart, again I don't know how sensible this is, feel free to comment Wyatt.

Although I haven't listed anyone in this PR, I'm wondering if @kevinmehall is able to be involved on behalf of Tessel.

I imagine that both IBM and Joyent would have strong interests in this process but may not want to join at this stage.

It's also possible that heavy users, beyond those I've listed, like PayPal and Netflix are interested in contributing to this effort, but again, unless they want to contribute people-power then I'd personally rather not see this overloaded this with talkers, that's not in the spirit of the open governance model we have going on here (i.e. basically, those who do the work get to decide).