### PR TITLE
readme: update LTS plan based on new release plan and openssl lts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,12 @@ The Current LTS Plan is:
 1. The next LTS release will be cut from the Converged Repo (nodejs/node) once
    the convergence of the joyent/node and nodejs/io.js streams has been
    completed. The current target is to move to the fully converged stream by
-   the end of August, 2015, with the first LTS release cut during the first
-   week of October, 2015.
+   the end of August, 2015, with the `v4.x` stable branch transitioning to LTS around the first week of October, 2015.
 2. After that, new LTS releases will occur once every 12 months, at the same
    time each year.
 3. Every LTS release will be actively maintained for a period of 18 months
-   from the date the LTS release is cut. After the 18 months have passed, the
-   release will transition into Maintenance mode until the current LTS
+   from the date the LTS release is announced. After the 18 months have passed,
+   the release will transition into Maintenance mode until the current LTS
    release moves into Maintenance 12 months later. (That is 18 months of
    active LTS + 12 months Maintenance only).
 4. There will be no more than two active LTS releases at any given time,
@@ -24,7 +23,7 @@ The Current LTS Plan is:
    approximately one year after the initial LTS release from the converged
    repo. The existing joyent/node v0.12 will continue in LTS for a period
    of 6 months after the initial LTS release from the converged repo,
-   after which it will transition into Maintenance for 12 months.
+   after which it will transition into Maintenance for 9 months**.
 6. There will be no LTS releases cut from the nodejs/io.js stream.
 7. Once a release enters LTS, no new features may be added to that release.
    Changes are limited to bug fixes, security updates, possible npm updates,
@@ -34,10 +33,12 @@ The Current LTS Plan is:
    permitted if required for critical security and bug fixes.
 8. Once a release moves into Maintenance mode, only ***critical*** bugs,
    ***critical*** security fixes, and documentation updates will be permitted.
-9. *semver-major* bumps are permitted *between* LTS releases. The LTS release
-   will be cut from the last stable release before a *semver-major* bump. The
-   implication of this is that the *semver-major* bump should be timed to
-   roughly coincide with the regular yearly LTS release schedule.
+9. The current release plan calls for stable branches to be cut off `master`
+   at approximately six month intervals. Each of these stable branches
+   represents exactly one *semver-major* version. There will be two of these
+   cut each year, an odd numbered stable, and an even numbered stable. Even
+   numbered stable branches will transition into LTS status, odd numbered
+   stable branches will not.
 10. Note that while it is possible that critical security and bug fixes may
     lead to *semver-major* changes landing within an LTS stream, such
     situations will be rare and will land as *semver-minor* bumps.
@@ -45,6 +46,14 @@ The Current LTS Plan is:
     elements on the Periodic Table of Elements. For each upcoming LTS
     release, the LTS Working Group will select a handful of candidate names
     and submit those for a collaborator vote.
+
+** LTS for the version of OpenSSL used by v0.12 (v1.0.1) is scheduled
+   to expire on 2016-12-31. While the typical maintenance LTS cycle
+   for a node release is 12 months, the LTS for OpenSSL v1.0.1 would
+   expire 3 months before the LTS for v0.12 would expire. The LTS WG
+   has therefore decided that the best approach is to shorten the
+   maintenance period for v0.12 and align it's end date with that of
+   OpenSSL v1.0.1's end date.
 
 ## Node abstraction layer
 
@@ -55,43 +64,40 @@ any given point in time, fully support a maximum of 2 LTS releases.
 
 ## Example
 
-The specific details may vary depending on the `next` and `master` release plan
-that is ultimately adopted. However, the release plan will not impact the
-schedule or proceses for managing an LTS release once it has been cut.
+Following the new release plan, at roughly six month intervals, a new stable
+branch is cut off `master`. Each stable branch represents a semver-major
+version. The first new stable branch cut off the converged stream will be
+`v4.0.0`. Assuming there are additional semver-minor and semver-patch bumps
+in that stable branch, the version could increase to some arbitrary number
+(e.g. `v4.4.1`). At around early October 2015, the v4.x stable branch will
+transition into the first LTS release and the `v5.0.0` stable branch will be
+created. While `v5.0.0` will be a stable branch, it will *not* transition into
+LTS.
 
-For example. Let's suppose that convergence of the source streams is completed.
-For the sake of the example, let's assume that the first converged stream
-release is v4.0.0 (the next major after the then current io.js release).
+Roughly six months later (in April 2016), a new stable branch will be created
+for `v6.0.0`. Approximately six months later, at around the same date the
+`v4.x` LTS was cut the previous year, `v6.x` will transition in to LTS and the
+cycle repeats.
 
-Let's suppose that the revised release plan currently being discussed in
-https://github.com/nodejs/io.js/issues/1997 is adopted. This would mean
-that there are regular, periodic merges from the `next` branch into `master`
-that trigger a `semver-major` bump (assuming at least two per year, six months
-apart). Let's assume that the current `master` immediately before the `next`
-merge is at v4.4.1. When the `semver-major` bump from `next` occurs, v4.4.1
-becomes the LTS release. If there are several merges from `next` into `master`
-through the year, the LTS release will still only occur once per year, at the
-same time each year.
-
-Let's assume (hypothetically) that this first LTS Release occurs on
+Let's assume (hypothetically) that the first LTS Release occurs on
 October 1st, 2015.
 
 1. nodejs/node v4.4.1 becomes the current LTS Release
 2. joyent/node v0.10 continues in Maintainance only mode until
    October 1st, 2016
 3. joyent/node v0.12 continues as LTS until April 1st, 2016, after
-   which it moves into Maintenance only mode until April 1st, 2017.
-4. On or around October 1st, 2016, the second LTS Release from the
-   converged is cut.
+   which it moves into Maintenance only mode until ~~April 1st, 2017~~
+   December 31st, 2016.
+4. On or around October 1st, 2016, `v6.x.x` transitions into
+   the second LTS release.
 5. LTS for v4.4.1 continues until April 1st, 2017, after which it
-   moves to Maintenance mode until around April 1st, 2017.
-6. On or around October 1st, 2017, the third LTS Release from the
-   converged is cut.
+   moves to Maintenance mode until around April 1st, 2018.
+6. On or around October 1st, 2017, `v8.x.x` transitions into
+   the third LTS release.
 
-Note that one implication of this schedule is that assuming that `next` merges
-into `master` twice per year, the LTS would be cut with a V8 version that is at
-least six months old and that will need to be supported for up to 30 months
-beyond the LTS release.
+Note that one implication of this schedule is that the LTS would include a V8
+version that is at least six months old and that will need to be supported for
+up to 30 months beyond the LTS release.
 
 <table>
 <tr>
@@ -110,7 +116,7 @@ beyond the LTS release.
   <td>v0.12</td>
   <td>(current)</td>
   <td>2016-04-01</td>
-  <td>2017-04-01</td>
+  <td>2016-12-31</td>
 </tr>
 <tr>
   <td>v4.4.1</td>
@@ -119,11 +125,14 @@ beyond the LTS release.
   <td>2018-04-01</td>
 </tr>
 <tr>
-  <td>v.Next</td>
+  <td>v6.x.x</td>
   <td>2016-10-01</td>
   <td>2018-04-01</td>
   <td>2019-04-01</td>
 </tr>
 </table>
 
-<p><img src="strawmanschedule.png" alt="Strawman LTS Schedule"/></p>
+<p><img src="https://camo.githubusercontent.com/675f052419c56a583c19644d4da30cc0ff4e02bb/68747470733a2f2f636c6475702e636f6d2f6c4d48746245334e72782d3330303078333030302e706e67" alt="Strawman LTS Schedule"/></p>
+
+(note: the diagram above shows v0.12 maintenance expiring in April 2017. That
+date has been changed to December 31st, 2016.)


### PR DESCRIPTION
* Update the details based on the adopted release plan
* Modify the v0.12 maintenance expiration date to align
  with OpenSSL v1.0.1 LTS end

/cc @nodejs/lts 