### PR TITLE
website: have website point to lts_schedule #493

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ beyond the LTS release.
   <td>2019-04-01</td>
 </tr>
 </table>
-
+<a name="lts_schedule"></a>
 _(Note: v4.2.0 has been the first official LTS release. [(Blog)](https://nodejs.org/en/blog/release/v4.2.0/))_
 
 <p><img src="schedule.png" alt="LTS Schedule"/></p>


### PR DESCRIPTION
as per discussion on nodejs/nodejs.org#493 and in reference to nodejs/nodejs.org#494. We would want to have a link to the picture of the schedule in the readme, instead of a link to the raw .png.

This would be much appreciated.