### PR TITLE
Correct v0.12 LTS End Date

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ beyond the LTS release.
   <td>v0.12</td>
   <td>(current)</td>
   <td>2016-04-01</td>
-  <td>2017-04-01</td>
+  <td>2016-04-01</td>
 </tr>
 <tr>
   <td>v4.2.0</td>


### PR DESCRIPTION
According to the release and support diagram, it seems that `v0.12` of node is slated to end LTS on April 1st, 2016. The table displayed however says that LTS for `v0.12` ends on April 1st, 2017. I think is an error?