### PR TITLE
doc: update table to show v0.12 EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <td>2016-10-31</td>
 </tr>
 <tr>
-  <td><b>Maintenance</b></td>
+  <td><b>End-of-Life</b></td>
   <td>v0.12</td>
   <td>-</td>
   <td>2016-04-01</td>


### PR DESCRIPTION
Update the table to reflect the current status of v0.12.

It's 2017 now!