### PR TITLE
doc: add list of LTS team members

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,15 @@ any given point in time, fully support a maximum of 2 LTS releases.
 [Google Calendar]: https://calendar.google.com/calendar/ical/eln7trd6k7n6asgg49bu2vqn4s%40group.calendar.google.com/public/basic.ics
 [JSON]: schedule.json
 [ICal]: schedule.ical
+
+## LTS Team members
+
+* Gibson Fahnestock [@gibfahn](https://github.com/gibfahn)
+* James M Snell [@jasnell](https://github.com/jasnell)
+* Jeremiah Senkpiel [@Fishrock123](https://github.com/Fishrock123)
+* Michael Dawson [@mhdawson](https://github.com/mhdawson)
+* Myles Borins [@MylesBorins](https://github.com/MylesBorins)
+* Rod Vagg [@rvagg](https://github.com/rvagg)
+* Sam Roberts [@sam-github](https://github.com/sam-github)
+
+Github team for LTS: https://github.com/orgs/nodejs/teams/lts


### PR DESCRIPTION
Went to create PR to add Sam and Gibson based on recent discussion in: https://github.com/nodejs/LTS/issues/189 and noticed we never actually added a list.

We should have this so people know how to contact for LTS related issues.

We do have a very old PR for a README revamp but its probably stale by now and I think we should add in the members separately.